### PR TITLE
Added support for extra_records_path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,14 +17,13 @@ headscale_bin_path: "{{ headscale_base_path }}/bin"
 headscale_config_path: "{{ headscale_base_path }}/config"
 headscale_data_path: "{{ headscale_base_path }}/data"
 
-# Controls the creation and mounting of the `extra-records.json` file
-# Set to a path, or an empty string to not create and mount
+# Controls the creation of the `extra-records.json` file
+# Set to "{{ headscale_data_path }}/extra-records.json", or an empty string to not create
 #
 # Mutually exclusive with `dns.extra_records`, enabling `headscale_extra_records_path` disables `headscale_config_dns_extra_records`
 #
 # Intended for use with a companion service, like Headplane, which modifies the contents of the file
 #
-# Example value: "{{ headscale_base_path }}/extra-records.json"
 # Learn more about it here:
 # - https://headscale.net/stable/ref/dns/#setting-extra-dns-records
 # - https://github.com/tale/headplane/blob/6d5e44f585469dd147b8c1dcc57f78fe9f7b0e72/config.example.yaml#L59

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,20 @@ headscale_identifier: headscale
 headscale_base_path: "/{{ headscale_identifier }}"
 headscale_bin_path: "{{ headscale_base_path }}/bin"
 headscale_config_path: "{{ headscale_base_path }}/config"
-headscale_extra_records_path: "{{ headscale_base_path }}/extra-records.json"
 headscale_data_path: "{{ headscale_base_path }}/data"
+
+# Controls the creation and mounting of the `extra-records.json` file
+# Set to a path, or an empty string to not create and mount
+#
+# Mutually exclusive with `dns.extra_records`, enabling `headscale_extra_records_path` disables `headscale_config_dns_extra_records`
+#
+# Intended for use with a companion service, like Headplane, which modifies the contents of the file
+#
+# Example value: "{{ headscale_base_path }}/extra-records.json"
+# Learn more about it here:
+# - https://headscale.net/stable/ref/dns/#setting-extra-dns-records
+# - https://github.com/tale/headplane/blob/6d5e44f585469dd147b8c1dcc57f78fe9f7b0e72/config.example.yaml#L59
+headscale_extra_records_path: ''
 
 # renovate: datasource=docker depName=headscale/headscale
 headscale_version: v0.27.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,17 +17,14 @@ headscale_bin_path: "{{ headscale_base_path }}/bin"
 headscale_config_path: "{{ headscale_base_path }}/config"
 headscale_data_path: "{{ headscale_base_path }}/data"
 
-# Controls the creation of the `extra-records.json` file
-# Set to "{{ headscale_data_path }}/extra-records.json", or an empty string to not create
-#
-# Mutually exclusive with `dns.extra_records`, enabling `headscale_extra_records_path` disables `headscale_config_dns_extra_records`
-#
+# Controls the creation of the 'extra-records.json' file
+# Mutually exclusive with `dns.extra_records`, setting this to true disables `headscale_config_dns_extra_records`
 # Intended for use with a companion service, like Headplane, which modifies the contents of the file
 #
 # Learn more about it here:
 # - https://headscale.net/stable/ref/dns/#setting-extra-dns-records
 # - https://github.com/tale/headplane/blob/6d5e44f585469dd147b8c1dcc57f78fe9f7b0e72/config.example.yaml#L59
-headscale_extra_records_path: ''
+headscale_extra_records_path_enabled: false
 
 # renovate: datasource=docker depName=headscale/headscale
 headscale_version: v0.27.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ headscale_identifier: headscale
 headscale_base_path: "/{{ headscale_identifier }}"
 headscale_bin_path: "{{ headscale_base_path }}/bin"
 headscale_config_path: "{{ headscale_base_path }}/config"
+headscale_extra_records_path: "{{ headscale_base_path }}/extra-records.json"
 headscale_data_path: "{{ headscale_base_path }}/data"
 
 # renovate: datasource=docker depName=headscale/headscale

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,6 +33,7 @@
     group: "{{ headscale_gid }}"
     modification_time: preserve
     access_time: preserve
+  when: headscale_extra_records_path
 
 - name: Ensure Headscale support files installed
   ansible.builtin.template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,12 +27,12 @@
 - name: Ensure Headscale extra-records.json file exists
   ansible.builtin.copy:
     content: "[]"
-    dest: "{{ headscale_extra_records_path }}"
+    dest: "{{ headscale_data_path }}/extra-records.json"
     mode: "0644"
     owner: "{{ headscale_uid }}"
     group: "{{ headscale_gid }}"
     force: false # Only modify/create the file if it doesn't already exist
-  when: headscale_extra_records_path
+  when: headscale_extra_records_path_enabled
 
 - name: Ensure Headscale support files installed
   ansible.builtin.template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,14 +25,13 @@
     group: "{{ headscale_gid }}"
 
 - name: Ensure Headscale extra-records.json file exists
-  ansible.builtin.file:
-    path: "{{ headscale_extra_records_path }}"
-    state: touch
+  ansible.builtin.copy:
+    content: "[]"
+    dest: "{{ headscale_extra_records_path }}"
     mode: "0644"
     owner: "{{ headscale_uid }}"
     group: "{{ headscale_gid }}"
-    modification_time: preserve
-    access_time: preserve
+    force: false # Only modify/create the file if it doesn't already exist
   when: headscale_extra_records_path
 
 - name: Ensure Headscale support files installed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,16 @@
     owner: "{{ headscale_uid }}"
     group: "{{ headscale_gid }}"
 
+- name: Ensure Headscale extra-records.json file exists
+  ansible.builtin.file:
+    path: "{{ headscale_extra_records_path }}"
+    state: touch
+    mode: "0644"
+    owner: "{{ headscale_uid }}"
+    group: "{{ headscale_gid }}"
+    modification_time: preserve
+    access_time: preserve
+
 - name: Ensure Headscale support files installed
   ansible.builtin.template:
     src: "{{ item.src }}"

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -285,6 +285,7 @@ dns:
   # Extra DNS records
   # so far only A and AAAA records are supported (on the tailscale side)
   # See: docs/ref/dns.md
+{% if not headscale_extra_records_path %}
   extra_records: {{ headscale_config_dns_extra_records | to_json }}
   #   - name: "grafana.myvpn.example.com"
   #     type: "A"
@@ -292,10 +293,11 @@ dns:
   #
   #   # you can also put it in one line
   #   - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.3" }
-  #
+{% else %}
   # Alternatively, extra DNS records can be loaded from a JSON file.
   # Headscale processes this file on each change.
   extra_records_path: /var/lib/headscale/extra-records.json
+{% endif %}
 
 # Unix socket used for the CLI to connect without authentication
 # Note: for production you will want to set this to something like:

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -295,7 +295,7 @@ dns:
   #
   # Alternatively, extra DNS records can be loaded from a JSON file.
   # Headscale processes this file on each change.
-  # extra_records_path: /var/lib/headscale/extra-records.json
+  extra_records_path: /var/lib/headscale/extra-records.json
 
 # Unix socket used for the CLI to connect without authentication
 # Note: for production you will want to set this to something like:

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -285,7 +285,7 @@ dns:
   # Extra DNS records
   # so far only A and AAAA records are supported (on the tailscale side)
   # See: docs/ref/dns.md
-{% if not headscale_extra_records_path %}
+{% if not headscale_extra_records_path_enabled %}
   extra_records: {{ headscale_config_dns_extra_records | to_json }}
   #   - name: "grafana.myvpn.example.com"
   #     type: "A"

--- a/templates/systemd/headscale.service.j2
+++ b/templates/systemd/headscale.service.j2
@@ -43,7 +43,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --env-file={{ headscale_base_path }}/env \
       --label-file={{ headscale_base_path }}/labels \
       --mount type=bind,src={{ headscale_config_path }},dst=/etc/headscale \
+      {% if headscale_extra_records_path %}
       --mount type=bind,src={{ headscale_extra_records_path }},dst=/var/lib/headscale/extra-records.json \
+      {% endif %}
       --mount type=bind,src={{ headscale_data_path }},dst=/var/lib/headscale \
       {% for volume in headscale_container_additional_volumes %}
       --mount type={{ volume.type | default('bind' if '/' in volume.src else 'volume') }},src={{ volume.src }},dst={{ volume.dst }}{{ (',' + volume.options) if volume.options else '' }} \

--- a/templates/systemd/headscale.service.j2
+++ b/templates/systemd/headscale.service.j2
@@ -43,9 +43,6 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --env-file={{ headscale_base_path }}/env \
       --label-file={{ headscale_base_path }}/labels \
       --mount type=bind,src={{ headscale_config_path }},dst=/etc/headscale \
-      {% if headscale_extra_records_path %}
-      --mount type=bind,src={{ headscale_extra_records_path }},dst=/var/lib/headscale/extra-records.json \
-      {% endif %}
       --mount type=bind,src={{ headscale_data_path }},dst=/var/lib/headscale \
       {% for volume in headscale_container_additional_volumes %}
       --mount type={{ volume.type | default('bind' if '/' in volume.src else 'volume') }},src={{ volume.src }},dst={{ volume.dst }}{{ (',' + volume.options) if volume.options else '' }} \

--- a/templates/systemd/headscale.service.j2
+++ b/templates/systemd/headscale.service.j2
@@ -43,6 +43,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --env-file={{ headscale_base_path }}/env \
       --label-file={{ headscale_base_path }}/labels \
       --mount type=bind,src={{ headscale_config_path }},dst=/etc/headscale \
+      --mount type=bind,src={{ headscale_extra_records_path }},dst=/var/lib/headscale/extra-records.json \
       --mount type=bind,src={{ headscale_data_path }},dst=/var/lib/headscale \
       {% for volume in headscale_container_additional_volumes %}
       --mount type={{ volume.type | default('bind' if '/' in volume.src else 'volume') }},src={{ volume.src }},dst={{ volume.dst }}{{ (',' + volume.options) if volume.options else '' }} \


### PR DESCRIPTION
Added support for `extra_records_path`, which enables dynamic DNS record modification at runtime.

This feature is ideal to support the creation of my new role, `headplane`.

Thoughts:
1. I wasn't exactly sure where to place this file outside of the container, `/config` didn't seem right since the existing mount would place the file in two different locations inside the container -- which could be confusing

3. If you enable the creation of the file then disable it later the file isn't deleted (seems similar to other roles)

3. The role does not have any mechanism to configure the contents of the `extra_records_path` file since its primary use is for integration with `headplane`, which can modify this file at runtime to support [DNS modification without a restart](https://github.com/tale/headplane/blob/6d5e44f585469dd147b8c1dcc57f78fe9f7b0e72/config.example.yaml#L59). A user of the `headscale` role but not the `headplane` role should use the existing `extra_records` variable instead. If it was possible to configure the contents of the `extra_records_path` file via this role it is likely conflicts would arise between modifications in the `headplane` UI and the corresponding Ansible variable.

Let me know if you have any questions or concerns. 
