### PR TITLE
Added a variable to control the policy.mode configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -320,6 +320,9 @@ headscale_config_log_format: text
 # Controls the `log.level` configuration value
 headscale_config_log_level: info
 
+# Controls the `policy.mode` configuration value
+headscale_config_policy_mode: file
+
 # Controls the `dns.magic_dns` configuration value
 headscale_config_dns_magic_dns: true
 

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -233,7 +233,7 @@ log:
 policy:
   # The mode can be "file" or "database" that defines
   # where the ACL policies are stored and read from.
-  mode: file
+  mode: {{ headscale_config_policy_mode | to_json }}
   # If the mode is set to "file", the path to a
   # HuJSON file containing ACL policies.
   path: ""


### PR DESCRIPTION
Added a variable to control the policy.mode configuration.

This is useful for integration w/ `headplane` per the following error when the value is `file`:

<img width="882" height="398" alt="image" src="https://github.com/user-attachments/assets/781b1f18-a5fa-4856-bf96-b7b81570d8e0" />

Adding support for this variable makes it easier to set the value to `database`, as `headplane` requests, as opposed to working with `headscale_configuration_extension_yaml` which is slightly more cumbersome
